### PR TITLE
Add is_affine() method to LocalizableFluxFunctionInterface

### DIFF
--- a/dune/xt/functions/affine.hh
+++ b/dune/xt/functions/affine.hh
@@ -501,6 +501,11 @@ public:
     BaseType::template helper<>::jacobian_col(col, A_, ret);
   }
 
+  virtual bool is_affine() const override
+  {
+    return true;
+  }
+
 private:
   using BaseType::A_;
   using BaseType::b_;

--- a/dune/xt/functions/interfaces/localizable-flux-function.hh
+++ b/dune/xt/functions/interfaces/localizable-flux-function.hh
@@ -68,6 +68,11 @@ public:
 
   virtual std::unique_ptr<LocalfunctionType> local_function(const EntityType& /*entity*/) const = 0;
 
+  virtual bool is_affine() const
+  {
+    return false;
+  }
+
   /**
    * \name ´´These methods should be implemented in order to identify the function.''
    * \{

--- a/dune/xt/functions/reinterpret.hh
+++ b/dune/xt/functions/reinterpret.hh
@@ -98,7 +98,7 @@ private:
     {
     }
 
-    virtual size_t order(const Common::Parameter& mu = {}) const override final
+    virtual size_t order(const Common::Parameter& /*mu*/ = {}) const override final
     {
       return order_;
     }

--- a/python/dune/xt/functions/checkerboard.hh
+++ b/python/dune/xt/functions/checkerboard.hh
@@ -14,9 +14,11 @@
 #include <dune/pybindxi/pybind11.h>
 
 #include <dune/xt/common/string.hh>
+
 #include <dune/xt/grid/dd/subdomains/grid.hh>
 #include <dune/xt/grid/type_traits.hh>
 #include <dune/xt/grid/gridprovider/provider.hh>
+
 #include <dune/xt/functions/interfaces.hh>
 #include <dune/xt/functions/checkerboard.hh>
 

--- a/python/dune/xt/functions/spe10.hh
+++ b/python/dune/xt/functions/spe10.hh
@@ -14,9 +14,11 @@
 #include <dune/pybindxi/pybind11.h>
 
 #include <dune/xt/common/string.hh>
+
 #include <dune/xt/grid/dd/subdomains/grid.hh>
 #include <dune/xt/grid/type_traits.hh>
 #include <dune/xt/grid/gridprovider/provider.hh>
+
 #include <dune/xt/functions/spe10/model1.hh>
 
 #include <python/dune/xt/common/fvector.hh>


### PR DESCRIPTION
In finite volume applications, we do not need to recalculate the jacobian for affine functions, so we should be able to detect affine functions.